### PR TITLE
Fix challenge pagination and lookup

### DIFF
--- a/src/GRA.Data/Model/ChallengeTask.cs
+++ b/src/GRA.Data/Model/ChallengeTask.cs
@@ -10,7 +10,8 @@ namespace GRA.Data.Model
     {
         [Required]
         public int ChallengeId { get; set; }
-
+        [Required]
+        public int Position { get; set; }
         [Required]
         [MaxLength(500)]
         public string Title { get; set; }

--- a/src/GRA.Data/Repository/ChallengeRepository.cs
+++ b/src/GRA.Data/Repository/ChallengeRepository.cs
@@ -59,17 +59,24 @@ namespace GRA.Data.Repository
             return genericRepo.AddSave(userId, dbEntity);
         }
 
-        public IQueryable<Domain.Model.Challenge> GetPagedChallengeList(int userId,
-            int skip,
-            int take)
+        public IQueryable<Domain.Model.Challenge> GetPagedChallengeList(int skip, int take)
         {
             // todo: add logic to filter for user
             return genericRepo.DbSet
                 .AsNoTracking()
                 .Where(_ => _.IsDeleted == false)
+                .OrderBy(_ => _.Name)
                 .Skip(skip)
                 .Take(take)
                 .ProjectTo<Domain.Model.Challenge>();
+        }
+
+        public int GetChallengeCount()
+        {
+            return genericRepo.DbSet
+                .AsNoTracking()
+                .Where(_ => _.IsDeleted == false)
+                .Count();
         }
 
         public Domain.Model.Challenge GetById(int id)

--- a/src/GRA.Domain.Model/ChallengeTask.cs
+++ b/src/GRA.Domain.Model/ChallengeTask.cs
@@ -11,6 +11,8 @@ namespace GRA.Domain.Model
         public int Id { get; set; }
         [Required]
         public int ChallengeId { get; set; }
+        [Required]
+        public int Position { get; set; }
 
         [Required]
         [MaxLength(500)]

--- a/src/GRA.Domain.Model/DataWithCount.cs
+++ b/src/GRA.Domain.Model/DataWithCount.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GRA.Domain.Model
+{
+    public class DataWithCount<DataType>
+    {
+        public DataType Data { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/src/GRA.Domain.Repository/IChallengeRepository.cs
+++ b/src/GRA.Domain.Repository/IChallengeRepository.cs
@@ -6,6 +6,7 @@ namespace GRA.Domain.Repository
     public interface IChallengeRepository : IRepository<Model.Challenge>
     {
         void AddChallengeTaskType(int userId, string name);
-        IQueryable<Challenge> GetPagedChallengeList(int userId, int skip, int take);
+        IQueryable<Challenge> GetPagedChallengeList(int skip, int take);
+        int GetChallengeCount();
     }
 }

--- a/src/GRA.Domain.Service/ChallengeService.cs
+++ b/src/GRA.Domain.Service/ChallengeService.cs
@@ -27,14 +27,18 @@ namespace GRA.Domain.Service
         /// <param name="user">A valid user</param>
         /// <param name="skip">The number of elements to skip before returning the remaining elements</param>
         /// <param name="take">The number of elements to return</param>
-        /// <returns></returns>
-        public IEnumerable<Challenge> GetPaginatedChallengeList(User user,
+        /// <returns><see cref="DataWithCount{DataType}"/> containing the challenges and the total challenge count</returns>
+        public DataWithCount<IEnumerable<Challenge>> GetPaginatedChallengeList(User user,
             int skip,
             int take)
         {
             // todo: fix user id
             // todo: add access control - only view authorized challenges
-            return challengeRepository.GetPagedChallengeList(0, skip, take);
+            return new DataWithCount<IEnumerable<Challenge>>
+            {
+                Data = challengeRepository.GetPagedChallengeList(skip, take),
+                Count = challengeRepository.GetChallengeCount()
+            };
         }
 
         /// <summary>
@@ -42,7 +46,7 @@ namespace GRA.Domain.Service
         /// </summary>
         /// <param name="user">A valid user</param>
         /// <param name="challengeId">A challenge id</param>
-        /// <returns></returns>
+        /// <returns>Details for the requested challenge</returns>
         public Challenge GetChallengeDetails(User user, int challengeId)
         {
             // todo: fix user id
@@ -55,7 +59,7 @@ namespace GRA.Domain.Service
         /// </summary>
         /// <param name="user">A valid user</param>
         /// <param name="challenge">A populated challenge object</param>
-        /// <returns></returns>
+        /// <returns>The challenge which was added with the Id property populated</returns>
         public Challenge AddChallenge(User user, Challenge challenge)
         {
             // todo: fix user id
@@ -68,7 +72,7 @@ namespace GRA.Domain.Service
         /// </summary>
         /// <param name="user">A valid user</param>
         /// <param name="challenge">The modified challenge object</param>
-        /// <returns></returns>
+        /// <returns>The updated challenge</returns>
         public Challenge EditChallenge(User user, Challenge challenge)
         {
             // todo: fix user id

--- a/src/GRA.Domain.Service/ConfigurationService.cs
+++ b/src/GRA.Domain.Service/ConfigurationService.cs
@@ -134,22 +134,26 @@ namespace GRA.Domain.Service
                 RelatedBranchId = branch.Id
             };
 
+            int positionCounter = 1;
             challenge.AddTask(creatorUserId, new Model.ChallengeTask
             {
                 Title = "Be excellent to each other",
-                ChallengeTaskType = Model.ChallengeTaskType.Action
+                ChallengeTaskType = Model.ChallengeTaskType.Action,
+                Position = positionCounter++
             });
             challenge.AddTask(creatorUserId, new Model.ChallengeTask
             {
                 Title = "Party on, dudes!",
-                ChallengeTaskType = Model.ChallengeTaskType.Action
+                ChallengeTaskType = Model.ChallengeTaskType.Action,
+                Position = positionCounter++
             });
             challenge.AddTask(creatorUserId, new Model.ChallengeTask
             {
                 Title = "Slaughterhouse-Five, or The Children's Crusade: A Duty-Dance with Death",
                 Author = "Kurt Vonnegut",
                 Isbn = "978-0385333849",
-                ChallengeTaskType = Model.ChallengeTaskType.Book
+                ChallengeTaskType = Model.ChallengeTaskType.Book,
+                Position = positionCounter++
             });
 
             challengeRepository.AddSave(creatorUserId, challenge);


### PR DESCRIPTION
- Add `DataWithCount` type for returning pagination collections with a
  total item count
- Fix `ChallengeService` to return a `DataWithCount` for paginated
  challenges
- Add missing return comments in `ChallengeService`
- Add `Position` property to `ChallengeTask` for ordering