### PR TITLE
Fix recovery token lookup, defaults

### DIFF
--- a/src/GRA.Data/Repository/RecoveryTokenRepository.cs
+++ b/src/GRA.Data/Repository/RecoveryTokenRepository.cs
@@ -20,29 +20,14 @@ namespace GRA.Data.Repository
         {
         }
 
-        private async Task<bool> UserHasTokens(int userId)
+        public async Task<IEnumerable<RecoveryToken>> GetByUserIdAsync(int userId)
         {
             return await DbSet
                 .AsNoTracking()
                 .Where(_ => _.UserId == userId)
-                .CountAsync() > 0;
-        }
-
-        public async Task<IEnumerable<RecoveryToken>> GetByUserIdAsync(int userId)
-        {
-            if (await UserHasTokens(userId))
-            {
-                return await DbSet
-                    .AsNoTracking()
-                    .Where(_ => _.UserId == userId)
-                    .OrderByDescending(_ => _.CreatedAt)
-                    .ProjectTo<RecoveryToken>()
-                    .ToListAsync();
-            }
-            else
-            {
-                return new List<RecoveryToken>();
-            }
+                .OrderByDescending(_ => _.CreatedAt)
+                .ProjectTo<RecoveryToken>()
+                .ToListAsync();
         }
     }
 }

--- a/src/GRA.Domain.Model/RecoveryToken.cs
+++ b/src/GRA.Domain.Model/RecoveryToken.cs
@@ -5,10 +5,9 @@ namespace GRA.Domain.Model
     public class RecoveryToken : Abstract.BaseDomainEntity
     {
         [Required]
-        public int UserId;
+        public int UserId { get; set; }
         [Required]
         [MaxLength(255)]
         public string Token { get; set; }
-
     }
 }

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -1,21 +1,32 @@
 ﻿using AutoMapper;
 using GRA.Controllers.RouteConstraint;
+using GRA.Domain.Service;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using System;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using GRA.Domain.Service;
+using System.Collections.Generic;
 using System.IO;
-using Microsoft.Extensions.FileProviders;
 
 namespace GRA.Web
 {
     public class Startup
     {
+        private IDictionary<string, string> _defaultSettings = new Dictionary<string, string>
+        {
+            { ConfigurationKey.DefaultSiteName, "The Great Reading Adventure" },
+            { ConfigurationKey.DefaultPageTitle, "Great Reading Adventure" },
+            { ConfigurationKey.DefaultSitePath, "gra" },
+            { ConfigurationKey.DefaultFooter, "This site is running the open source <a href=\"http://www.greatreadingadventure.com/\">Great Reading Adventure</a> software developed by the <a href=\"https://mcldaz.org/\">Maricopa County Library District</a> with support by the <a href=\"http://www.azlibrary.gov/\">Arizona State Library, Archives and Public Records</a>, a division of the Secretary of State, and with federal funds from the <a href=\"http://www.imls.gov/\">Institute of Museum and Library Services</a>." },
+            { ConfigurationKey.InitialAuthorizationCode, "gra4adminmagic" },
+            { ConfigurationKey.ContentDirectory, "content" }
+        };
+
         public Startup(IHostingEnvironment env)
         {
             var builder = new ConfigurationBuilder()
@@ -31,35 +42,27 @@ namespace GRA.Web
             builder.AddEnvironmentVariables();
 
             Configuration = builder.Build();
-            if (string.IsNullOrEmpty(Configuration[ConfigurationKey.DefaultSiteName]))
+
+            foreach (var configKey in _defaultSettings.Keys)
             {
-                Configuration[ConfigurationKey.DefaultSiteName] = "The Great Reading Adventure";
-            }
-            if (string.IsNullOrEmpty(Configuration[ConfigurationKey.DefaultPageTitle]))
-            {
-                Configuration[ConfigurationKey.DefaultPageTitle] = "Great Reading Adventure";
-            }
-            if (string.IsNullOrEmpty(Configuration[ConfigurationKey.DefaultSitePath]))
-            {
-                Configuration[ConfigurationKey.DefaultSitePath] = "gra";
-            }
-            if (string.IsNullOrEmpty(Configuration[ConfigurationKey.DefaultFooter]))
-            {
-                Configuration[ConfigurationKey.DefaultFooter] = "This site is running the open source <a href=\"http://www.greatreadingadventure.com/\">Great Reading Adventure</a> software developed by the <a href=\"https://mcldaz.org/\">Maricopa County Library District</a> with support by the <a href=\"http://www.azlibrary.gov/\">Arizona State Library, Archives and Public Records</a>, a division of the Secretary of State, and with federal funds from the <a href=\"http://www.imls.gov/\">Institute of Museum and Library Services</a>.";
-            }
-            if (string.IsNullOrEmpty(Configuration[ConfigurationKey.InitialAuthorizationCode]))
-            {
-                Configuration[ConfigurationKey.InitialAuthorizationCode] = "gra4adminmagic";
-            }
-            if (string.IsNullOrEmpty(Configuration[ConfigurationKey.ContentDirectory]))
-            {
-                Configuration[ConfigurationKey.ContentDirectory] = "content";
+                if (string.IsNullOrEmpty(Configuration[configKey]))
+                {
+                    Configuration[configKey] = _defaultSettings[configKey];
+                }
             }
 
             if (env.IsDevelopment())
             {
-                Configuration[ConfigurationKey.DefaultCSSqlServer] = DefaultConnectionString.SqlServer;
-                Configuration[ConfigurationKey.DefaultCSSQLite] = DefaultConnectionString.SQLite;
+                if (string.IsNullOrEmpty(Configuration[ConfigurationKey.DefaultCSSqlServer]))
+                {
+                    Configuration[ConfigurationKey.DefaultCSSqlServer] 
+                        = DefaultConnectionString.SqlServer;
+                }
+                if (string.IsNullOrEmpty(Configuration[ConfigurationKey.DefaultCSSQLite]))
+                {
+                    Configuration[ConfigurationKey.DefaultCSSQLite] 
+                        = DefaultConnectionString.SQLite;
+                }
             }
 
             string contentDirectory = Configuration[ConfigurationKey.ContentDirectory];


### PR DESCRIPTION
- Fix recovery token lookup to remove unnecessary count call
- Make `UserId` on `Domain.Model.RecoveryToken` a proper field
- Simplify default settings